### PR TITLE
Cambio de letra de path en cargaFolios view

### DIFF
--- a/application/views/contabilidad/cargaFolios_view.php
+++ b/application/views/contabilidad/cargaFolios_view.php
@@ -148,5 +148,5 @@
     <script src="<?= base_url() ?>dist/js/jwt/enc-base64-min.js"></script>
     <script src="<?= base_url() ?>dist/js/controllers/general/main_services.js"></script>
     <script src="<?= base_url() ?>dist/js/core/modal-general.js"></script>
-    <script src="<?= base_url() ?>dist/js/controllers/Contabilidad/cargaFolios.js"></script>
+    <script src="<?= base_url() ?>dist/js/controllers/contabilidad/cargaFolios.js"></script>
 </body>


### PR DESCRIPTION
Se cambió el path para llamar el JS en donde se tenia Contabilidad y pasó a contabilidad en minúscula. 